### PR TITLE
AUTO-605 Investigate vector nav segfault

### DIFF
--- a/vectornav/config/vectornav.yaml
+++ b/vectornav/config/vectornav.yaml
@@ -1,75 +1,101 @@
 vectornav:
   ros__parameters:
-    port: "/dev/ttyUSB0"
-    baud: 115200
-    reconnect_ms: 500
+    port: "/dev/vectornav_imu"
+    baud: 921600
+    adjust_ros_timestamp: True
+    reconnect_ms: 2000
     # Reference vnproglib-1.2.0.0 headers for enum definitions
     # Async Output Type (ASCII)
-    AsyncDataOutputType: 0           # VNOFF
+    # leave this at zero to select binary format
+    AsyncDataOutputType: 13 # VNOFF
     # Async output Frequency (Hz)
-    AsyncDataOutputFrequency: 20
+    # Not sure why this has to be 1Hz to make it work. Very strange.
+    AsyncDataOutputFrequency: 200
     # Sync control
-    syncInMode: 3                    # SYNCINMODE_COUNT
-    syncInEdge: 0                    # SYNCINEDGE_RISING
+    syncInMode: 3 # SYNCINMODE_COUNT
+    syncInEdge: 0 # SYNCINEDGE_RISING
     syncInSkipFactor: 0
-    syncOutMode: 0                   # SYNCOUTMODE_NONE
-    syncOutPolarity: 0               # SYNCOUTPOLARITY_NEGATIVE
+    syncOutMode: 0 # SYNCOUTMODE_NONE
+    syncOutPolarity: 0 # SYNCOUTPOLARITY_NEGATIVE
     syncOutSkipFactor: 0
     syncOutPulseWidth_ns: 100000000
     # Communication protocol control
-    serialCount: 0                   # COUNTMODE_NONE
-    serialStatus: 0                  # STATUSMODE_OFF
-    spiCount: 0                      # COUNTMODE_NONE
-    spiStatus: 0                     # STATUSMODE_OFF
-    serialChecksum: 1                # CHECKSUMMODE_CHECKSUM
-    spiChecksum: 0                   # CHECKSUMMODE_OFF
-    errorMode: 1                     # ERRORMODE_SEND
+    serialCount: 0 # COUNTMODE_NONE
+    serialStatus: 0 # STATUSMODE_OFF
+    spiCount: 0 # COUNTMODE_NONE
+    spiStatus: 0 # STATUSMODE_OFF
+    serialChecksum: 1 # CHECKSUMMODE_CHECKSUM
+    spiChecksum: 0 # CHECKSUMMODE_OFF
+    errorMode: 1 # ERRORMODE_SEND
     # Binary output register 1
     BO1:
-      asyncMode: 3                   # ASYNCMODE_BOTH
-      rateDivisor: 40                # 20 Hz
-      commonField: 0x7FFF
-      timeField: 0x0000              # TIMEGROUP_NONE
-      imuField: 0x0000               # IMUGROUP_NONE
+      asyncMode: 1 # send only on port 1 to save serial bandwidth
+      rateDivisor: 8 # 100 Hz
+      #
+      # TimeStartup
+      # bit name         meaning
+      # 0   TimeStartup  Time since startup.
+      # 1   Reserved     Reserved. Not used on this product.
+      # 2   TimeSyncIn   Time since last SyncIn trigger.
+      # 3   Ypr          Estimated attitude as yaw pitch and roll angles.
+      # 4   Qtn          Estimated attitude as a quaternion.
+      # 5   AngularRate  Compensated angular rate.
+      # 6   Reserved     Reserved. Not used on this product.
+      # 7   Reserved     Reserved. Not used on this product.
+      # 8   Accel        Estimated acceleration (compensated). (Body)
+      # 9   Imu          Calibrated uncompensated gyro and accelerometer measurements.
+      # 10  MagPres      Calibrated magnetic (compensated), temperature, and pressure measurements.
+      # 11  DeltaTheta   Delta time, theta, and velocity.
+      # 12  AhrsStatus
+      # 13  SyncInCnt
+      # 14  Reserved
+      # 15  Resv
+      #
+      # To get just the calibrated but otherwise uncompensated imu measurements, use these
+      # flags:
+      # bit: 111
+      #      2109876543210
+      #   s="0001000000001" (switch on bits 0 and 9 only)
+      #
+      # python code: convert to hex via:  hex(int("0001000000001", 2)) -> 0x201
+      #
+      # commonField: 0x7FFF          # cannot request all fields at full frequency
+      commonField: 0x201 # ask for only bare bones IMU data
+      timeField: 0x0000 # TIMEGROUP_NONE
+      imuField: 0x0000 # IMUGROUP_NONE
       # set gpsField directly in source to enforce or condition
-      attitudeField: 0x0000          # ATTITUDEGROUP_NONE
+      attitudeField: 0x0000 # ATTITUDEGROUP_NONE
       # set insField directly in source to enforce or condition
-      gps2Field: 0x0000              # GPSGROUP_NONE
+      gps2Field: 0x0000 # GPSGROUP_NONE
     # Binary output register 2
     BO2:
-      asyncMode: 0                   # ASYNCMODE_NONE
+      asyncMode: 0 # ASYNCMODE_NONE
       rateDivisor: 0
-      commonField: 0x0000            # COMMONGROUP_NONE
-      timeField: 0x0000              # TIMEGROUP_NONE
-      imuField: 0x0000               # IMUGROUP_NONE
-      gpsField: 0x0000               # GPSGROUP_NONE
-      attitudeField: 0x0000          # ATTITUDEGROUP_NONE
-      insField: 0x0000               # INSGROUP_NONE
-      gps2Field: 0x0000              # GPSGROUP_NONE
+      commonField: 0x0000 # COMMONGROUP_NONE
+      timeField: 0x0000 # TIMEGROUP_NONE
+      imuField: 0x0000 # IMUGROUP_NONE
+      gpsField: 0x0000 # GPSGROUP_NONE
+      attitudeField: 0x0000 # ATTITUDEGROUP_NONE
+      insField: 0x0000 # INSGROUP_NONE
+      gps2Field: 0x0000 # GPSGROUP_NONE
     # Binary output register 3
     BO3:
-      asyncMode: 0                   # ASYNCMODE_NONE
+      asyncMode: 0 # ASYNCMODE_NONE
       rateDivisor: 0
-      commonField: 0x0000            # COMMONGROUP_NONE
-      timeField: 0x0000              # TIMEGROUP_NONE
-      imuField: 0x0000               # IMUGROUP_NONE
-      gpsField: 0x0000               # GPSGROUP_NONE
-      attitudeField: 0x0000          # ATTITUDEGROUP_NONE
-      insField: 0x0000               # INSGROUP_NONE
-      gps2Field: 0x0000              # GPSGROUP_NONE
-    frame_id: "vectornav"
+      commonField: 0x0000 # COMMONGROUP_NONE
+      timeField: 0x0000 # TIMEGROUP_NONE
+      imuField: 0x0000 # IMUGROUP_NONE
+      gpsField: 0x0000 # GPSGROUP_NONE
+      attitudeField: 0x0000 # ATTITUDEGROUP_NONE
+      insField: 0x0000 # INSGROUP_NONE
+      gps2Field: 0x0000 # GPSGROUP_NONE
+    frame_id: "vn100_link"
 
 vn_sensor_msgs:
   ros__parameters:
-    orientation_covariance: [0.01,  0.0,   0.0,
-                            0.0,   0.01,  0.0,
-                            0.0,   0.0,   0.01]
-    angular_velocity_covariance: [0.01,  0.0,   0.0,
-                         0.0,   0.01,  0.0,
-                         0.0,   0.0,   0.01]
-    linear_acceleration_covariance: [0.01,  0.0,   0.0,
-                         0.0,   0.01,  0.0,
-                         0.0,   0.0,   0.01]
-    magnetic_covariance: [0.01,  0.0,   0.0,
-                         0.0,   0.01,  0.0,
-                         0.0,   0.0,   0.01]
+    orientation_covariance: [0.01, 0.0, 0.0, 0.0, 0.01, 0.0, 0.0, 0.0, 0.01]
+    angular_velocity_covariance:
+      [0.01, 0.0, 0.0, 0.0, 0.01, 0.0, 0.0, 0.0, 0.01]
+    linear_acceleration_covariance:
+      [0.01, 0.0, 0.0, 0.0, 0.01, 0.0, 0.0, 0.0, 0.01]
+    magnetic_covariance: [0.01, 0.0, 0.0, 0.0, 0.01, 0.0, 0.0, 0.0, 0.01]

--- a/vectornav/config/vectornav.yaml
+++ b/vectornav/config/vectornav.yaml
@@ -1,101 +1,75 @@
 vectornav:
   ros__parameters:
-    port: "/dev/vectornav_imu"
-    baud: 921600
-    adjust_ros_timestamp: True
-    reconnect_ms: 2000
+    port: "/dev/ttyUSB0"
+    baud: 115200
+    reconnect_ms: 500
     # Reference vnproglib-1.2.0.0 headers for enum definitions
     # Async Output Type (ASCII)
-    # leave this at zero to select binary format
-    AsyncDataOutputType: 13 # VNOFF
+    AsyncDataOutputType: 0           # VNOFF
     # Async output Frequency (Hz)
-    # Not sure why this has to be 1Hz to make it work. Very strange.
-    AsyncDataOutputFrequency: 200
+    AsyncDataOutputFrequency: 20
     # Sync control
-    syncInMode: 3 # SYNCINMODE_COUNT
-    syncInEdge: 0 # SYNCINEDGE_RISING
+    syncInMode: 3                    # SYNCINMODE_COUNT
+    syncInEdge: 0                    # SYNCINEDGE_RISING
     syncInSkipFactor: 0
-    syncOutMode: 0 # SYNCOUTMODE_NONE
-    syncOutPolarity: 0 # SYNCOUTPOLARITY_NEGATIVE
+    syncOutMode: 0                   # SYNCOUTMODE_NONE
+    syncOutPolarity: 0               # SYNCOUTPOLARITY_NEGATIVE
     syncOutSkipFactor: 0
     syncOutPulseWidth_ns: 100000000
     # Communication protocol control
-    serialCount: 0 # COUNTMODE_NONE
-    serialStatus: 0 # STATUSMODE_OFF
-    spiCount: 0 # COUNTMODE_NONE
-    spiStatus: 0 # STATUSMODE_OFF
-    serialChecksum: 1 # CHECKSUMMODE_CHECKSUM
-    spiChecksum: 0 # CHECKSUMMODE_OFF
-    errorMode: 1 # ERRORMODE_SEND
+    serialCount: 0                   # COUNTMODE_NONE
+    serialStatus: 0                  # STATUSMODE_OFF
+    spiCount: 0                      # COUNTMODE_NONE
+    spiStatus: 0                     # STATUSMODE_OFF
+    serialChecksum: 1                # CHECKSUMMODE_CHECKSUM
+    spiChecksum: 0                   # CHECKSUMMODE_OFF
+    errorMode: 1                     # ERRORMODE_SEND
     # Binary output register 1
     BO1:
-      asyncMode: 1 # send only on port 1 to save serial bandwidth
-      rateDivisor: 8 # 100 Hz
-      #
-      # TimeStartup
-      # bit name         meaning
-      # 0   TimeStartup  Time since startup.
-      # 1   Reserved     Reserved. Not used on this product.
-      # 2   TimeSyncIn   Time since last SyncIn trigger.
-      # 3   Ypr          Estimated attitude as yaw pitch and roll angles.
-      # 4   Qtn          Estimated attitude as a quaternion.
-      # 5   AngularRate  Compensated angular rate.
-      # 6   Reserved     Reserved. Not used on this product.
-      # 7   Reserved     Reserved. Not used on this product.
-      # 8   Accel        Estimated acceleration (compensated). (Body)
-      # 9   Imu          Calibrated uncompensated gyro and accelerometer measurements.
-      # 10  MagPres      Calibrated magnetic (compensated), temperature, and pressure measurements.
-      # 11  DeltaTheta   Delta time, theta, and velocity.
-      # 12  AhrsStatus
-      # 13  SyncInCnt
-      # 14  Reserved
-      # 15  Resv
-      #
-      # To get just the calibrated but otherwise uncompensated imu measurements, use these
-      # flags:
-      # bit: 111
-      #      2109876543210
-      #   s="0001000000001" (switch on bits 0 and 9 only)
-      #
-      # python code: convert to hex via:  hex(int("0001000000001", 2)) -> 0x201
-      #
-      # commonField: 0x7FFF          # cannot request all fields at full frequency
-      commonField: 0x201 # ask for only bare bones IMU data
-      timeField: 0x0000 # TIMEGROUP_NONE
-      imuField: 0x0000 # IMUGROUP_NONE
+      asyncMode: 3                   # ASYNCMODE_BOTH
+      rateDivisor: 40                # 20 Hz
+      commonField: 0x7FFF
+      timeField: 0x0000              # TIMEGROUP_NONE
+      imuField: 0x0000               # IMUGROUP_NONE
       # set gpsField directly in source to enforce or condition
-      attitudeField: 0x0000 # ATTITUDEGROUP_NONE
+      attitudeField: 0x0000          # ATTITUDEGROUP_NONE
       # set insField directly in source to enforce or condition
-      gps2Field: 0x0000 # GPSGROUP_NONE
+      gps2Field: 0x0000              # GPSGROUP_NONE
     # Binary output register 2
     BO2:
-      asyncMode: 0 # ASYNCMODE_NONE
+      asyncMode: 0                   # ASYNCMODE_NONE
       rateDivisor: 0
-      commonField: 0x0000 # COMMONGROUP_NONE
-      timeField: 0x0000 # TIMEGROUP_NONE
-      imuField: 0x0000 # IMUGROUP_NONE
-      gpsField: 0x0000 # GPSGROUP_NONE
-      attitudeField: 0x0000 # ATTITUDEGROUP_NONE
-      insField: 0x0000 # INSGROUP_NONE
-      gps2Field: 0x0000 # GPSGROUP_NONE
+      commonField: 0x0000            # COMMONGROUP_NONE
+      timeField: 0x0000              # TIMEGROUP_NONE
+      imuField: 0x0000               # IMUGROUP_NONE
+      gpsField: 0x0000               # GPSGROUP_NONE
+      attitudeField: 0x0000          # ATTITUDEGROUP_NONE
+      insField: 0x0000               # INSGROUP_NONE
+      gps2Field: 0x0000              # GPSGROUP_NONE
     # Binary output register 3
     BO3:
-      asyncMode: 0 # ASYNCMODE_NONE
+      asyncMode: 0                   # ASYNCMODE_NONE
       rateDivisor: 0
-      commonField: 0x0000 # COMMONGROUP_NONE
-      timeField: 0x0000 # TIMEGROUP_NONE
-      imuField: 0x0000 # IMUGROUP_NONE
-      gpsField: 0x0000 # GPSGROUP_NONE
-      attitudeField: 0x0000 # ATTITUDEGROUP_NONE
-      insField: 0x0000 # INSGROUP_NONE
-      gps2Field: 0x0000 # GPSGROUP_NONE
-    frame_id: "vn100_link"
+      commonField: 0x0000            # COMMONGROUP_NONE
+      timeField: 0x0000              # TIMEGROUP_NONE
+      imuField: 0x0000               # IMUGROUP_NONE
+      gpsField: 0x0000               # GPSGROUP_NONE
+      attitudeField: 0x0000          # ATTITUDEGROUP_NONE
+      insField: 0x0000               # INSGROUP_NONE
+      gps2Field: 0x0000              # GPSGROUP_NONE
+    frame_id: "vectornav"
 
 vn_sensor_msgs:
   ros__parameters:
-    orientation_covariance: [0.01, 0.0, 0.0, 0.0, 0.01, 0.0, 0.0, 0.0, 0.01]
-    angular_velocity_covariance:
-      [0.01, 0.0, 0.0, 0.0, 0.01, 0.0, 0.0, 0.0, 0.01]
-    linear_acceleration_covariance:
-      [0.01, 0.0, 0.0, 0.0, 0.01, 0.0, 0.0, 0.0, 0.01]
-    magnetic_covariance: [0.01, 0.0, 0.0, 0.0, 0.01, 0.0, 0.0, 0.0, 0.01]
+    orientation_covariance: [0.01,  0.0,   0.0,
+                            0.0,   0.01,  0.0,
+                            0.0,   0.0,   0.01]
+    angular_velocity_covariance: [0.01,  0.0,   0.0,
+                         0.0,   0.01,  0.0,
+                         0.0,   0.0,   0.01]
+    linear_acceleration_covariance: [0.01,  0.0,   0.0,
+                         0.0,   0.01,  0.0,
+                         0.0,   0.0,   0.01]
+    magnetic_covariance: [0.01,  0.0,   0.0,
+                         0.0,   0.01,  0.0,
+                         0.0,   0.0,   0.01]

--- a/vectornav/src/vectornav.cc
+++ b/vectornav/src/vectornav.cc
@@ -415,33 +415,37 @@ private:
     configBO3.gps2Field = (vn::protocol::uart::GpsGroup)get_parameter("BO3.gps2Field").as_int();
     vs_.writeBinaryOutput3(configBO3);
 
-    try {
-      // GPS Configuration
-      // 8.2.1
-      auto gps_config = vs_.readGpsConfiguration();
-      RCLCPP_INFO(get_logger(), "GPS Mode       : %d", gps_config.mode);
-      RCLCPP_INFO(get_logger(), "GPS PPS Source : %d", gps_config.ppsSource);
-      /// TODO(Dereck): VnSensor::readGpsConfiguration() missing fields
+    // If the sensor is from the VN100 family skip the GPS init completely as it doesn't have 
+    // GNSS
+    if (vs_.determineDeviceFamily() != vn::sensors::VnSensor::VnSensor_Family_Vn100) {
+      try {
+        // GPS Configuration
+        // 8.2.1
+        auto gps_config = vs_.readGpsConfiguration();
+        RCLCPP_INFO(get_logger(), "GPS Mode       : %d", gps_config.mode);
+        RCLCPP_INFO(get_logger(), "GPS PPS Source : %d", gps_config.ppsSource);
+        /// TODO(Dereck): VnSensor::readGpsConfiguration() missing fields
 
-      // GPS Offset
-      // 8.2.2
-      auto gps_offset = vs_.readGpsAntennaOffset();
-      RCLCPP_INFO(
-        get_logger(), "GPS Offset     : (%f, %f, %f)", gps_offset[0], gps_offset[1], gps_offset[2]);
-
-      // GPS Compass Baseline
-      // 8.2.3
-      // According to dawonn, readGpsCompassBaseline is likely only available
-      // on the VN-300
-      if (vs_.determineDeviceFamily() == vn::sensors::VnSensor::VnSensor_Family_Vn300) {
-        auto gps_baseline = vs_.readGpsCompassBaseline();
+        // GPS Offset
+        // 8.2.2
+        auto gps_offset = vs_.readGpsAntennaOffset();
         RCLCPP_INFO(
-          get_logger(), "GPS Baseline     : (%f, %f, %f), (%f, %f, %f)", gps_baseline.position[0],
-          gps_baseline.position[1], gps_baseline.position[2], gps_baseline.uncertainty[0],
-          gps_baseline.uncertainty[1], gps_baseline.uncertainty[2]);
+          get_logger(), "GPS Offset     : (%f, %f, %f)", gps_offset[0], gps_offset[1], gps_offset[2]);
+
+        // GPS Compass Baseline
+        // 8.2.3
+        // According to dawonn, readGpsCompassBaseline is likely only available
+        // on the VN-300
+        if (vs_.determineDeviceFamily() == vn::sensors::VnSensor::VnSensor_Family_Vn300) {
+          auto gps_baseline = vs_.readGpsCompassBaseline();
+          RCLCPP_INFO(
+            get_logger(), "GPS Baseline     : (%f, %f, %f), (%f, %f, %f)", gps_baseline.position[0],
+            gps_baseline.position[1], gps_baseline.position[2], gps_baseline.uncertainty[0],
+            gps_baseline.uncertainty[1], gps_baseline.uncertainty[2]);
+        }
+      } catch (const vn::sensors::sensor_error & e) {
+        RCLCPP_WARN(get_logger(), "GPS initialization error (does your sensor have one?)");
       }
-    } catch (const vn::sensors::sensor_error & e) {
-      RCLCPP_WARN(get_logger(), "GPS initialization error (does your sensor have one?)");
     }
     // Register Binary Data Callback
     vs_.registerAsyncPacketReceivedHandler(this, Vectornav::AsyncPacketReceivedHandler);

--- a/vectornav/src/vectornav.cc
+++ b/vectornav/src/vectornav.cc
@@ -187,7 +187,7 @@ public:
     if (vs_){
       vs_->unregisterErrorPacketReceivedHandler();
       vs_->unregisterAsyncPacketReceivedHandler();
-      if (vs_->isConnected()) 
+      if (vs_->isConnected())
         vs_->disconnect();
       vs_.reset();
     }

--- a/vectornav/src/vectornav.cc
+++ b/vectornav/src/vectornav.cc
@@ -241,7 +241,9 @@ private:
         vs_.disconnect();
       }
     } catch (...) {
-      // Don't care
+      // Do care!
+      std::exception_ptr p = std::current_exception();
+      RCLCPP_ERROR(get_logger(), "Error connecting to sensor: %s", p.__cxa_exception_type()->name());
     }
   }
 
@@ -278,7 +280,9 @@ private:
           break;
         }
       } catch (...) {
-        // Don't care...
+        // Do care!
+        std::exception_ptr p = std::current_exception();
+        RCLCPP_ERROR(get_logger(), "Error connecting to sensor: %s", p.__cxa_exception_type()->name());
       }
     }
 


### PR DESCRIPTION
[JIRA LINK](https://dexory.atlassian.net/browse/AUTO-605)

This is a draft PR with a bunch of changes, I will clean it up and probably separate the fixes so I can also push them upstream at some point. The main issue I found is the driver is creating a **lot** of threads and never cleaning them up. Every time it attempts to open a port which is does at least 9 times (for all the support baud rates) and every time it tries to reconnect these threads aren't cleaned up. 

At least some of the time these threads are attached to the static callbacks in the main node which means multiple threads can access the same callbacks and mess things up. I've updated things so all the port threads are properly cleaned up. 

**BONUS**  I've also added a check for the model type so it doesn't have this GPS initialisation error any more. All the VN100 family of sensors don't have GPS so it doesn't make sense to even try to initialise it.

 